### PR TITLE
Fixing link

### DIFF
--- a/documentation/mkdocs-slae.sh/docs/projects/cc2652.md
+++ b/documentation/mkdocs-slae.sh/docs/projects/cc2652.md
@@ -393,7 +393,7 @@ Emails are hard to track and are getting messy real quickly..
 
 So just text us on [Telegram] for any requests and technical support!
 
-[explanation here]: https://www.zigbee2mqtt.io/how_tos/how_to_improve_network_range.html#connect-the-cc2531-using-an-usb-extension-cable
+[explanation here]: https://www.zigbee2mqtt.io/how_tos/how_to_improve_network_range_and_stability.html
 [mail]: mailto:order@slae.sh
 [email]: mailto:order@slae.sh
 [zigbee2mqtt]: https://github.com/Koenkk/zigbee2mqtt


### PR DESCRIPTION
The link to "How to improve network range and stability" was broken, replaced with the new/correct one.